### PR TITLE
Bug fix

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -213,9 +213,7 @@ Wallet.prototype.createTx = function(to, value, fee, minConf, unspents) {
     subTotal = value + estimatedFee
     if (accum >= subTotal) {
       var change = accum - subTotal
-      console.log("fee: " + fee + " og value " + value);
-      if (3*fee > value) { // SKOÐA - ef 3x fee > sent þá dustThreshold eins og í smiley kóða
-        console.log("fee: " + fee + " og value " + value);
+      if (change > 3*fee) { // SKOÐA - ef 3x fee > sent þá dustThreshold eins og í smiley kóða
         builder.addOutput(that.getNextChangeAddress(), change)
       }
 


### PR DESCRIPTION
Issue fixed where you couldn't send from the HTML5 (coinspace) wallet unless the value was really close to the value of an single utxo (under 3 smileycoins)